### PR TITLE
Create noise color

### DIFF
--- a/examples/noise_color_waves.rs
+++ b/examples/noise_color_waves.rs
@@ -1,0 +1,54 @@
+use fundsp::hacker::*;
+
+
+enum NoiseColor {
+    Brown,
+    Pink,
+    White,
+}
+
+
+impl NoiseColor {
+    fn render(&self, normalize: bool) -> Wave64 {
+        let mut wave = match self {
+            Self::Brown => Wave64::render(44100.0, 3.0, &mut (brown())),
+            Self::Pink => Wave64::render(44100.0, 3.0, &mut (pink())),
+            Self::White => Wave64::render(44100.0, 3.0, &mut (white())),
+        };
+
+        if normalize {
+            wave.normalize();
+        }
+
+        return wave;
+    }
+}
+
+
+fn main() {
+    println!("Hello, world!");
+
+    let color = NoiseColor::Brown;
+    let mut node = (pass() | lfo(|t| (xerp11(110.0, 880.0, spline_noise(0, t*5.0)), 10.))) >> bandpass();
+    let normalize = true;
+
+    color
+        .render(normalize)
+        .filter(3.0, &mut node)
+        .save_wav16("test/sounds/brown_noise_filtered.wav")
+        .expect("Could not save file.");
+
+    let color = NoiseColor::Pink;
+    color
+        .render(normalize)
+        .filter(3.0, &mut node)
+        .save_wav16("test/sounds/pink_noise_filtered.wav")
+        .expect("Could not save file.");
+
+    let color = NoiseColor::White;
+    color
+        .render(normalize)
+        .filter(3.0, &mut node)
+        .save_wav16("test/sounds/white_noise_filtered.wav")
+        .expect("Could not save file.");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,23 +25,25 @@ fn main() {
     println!("Hello, world!");
 
     let color = NoiseColor::Brown;
+    let mut node = (pass() | lfo(|t| (xerp11(110.0, 880.0, spline_noise(0, t*5.0)), 10.))) >> bandpass();
+
     color
         .render()
-        .filter(3.0, &mut((pass() | lfo(|t| (xerp11(110.0, 880.0, spline_noise(0, t*5.0)), 10.))) >> bandpass()))
+        .filter(3.0, &mut node)
         .save_wav16("test/sounds/brown_noise_filtered.wav")
         .expect("Could not save file.");
 
     let color = NoiseColor::Pink;
     color
         .render()
-        .filter(3.0, &mut((pass() | lfo(|t| (xerp11(110.0, 880.0, spline_noise(0, t*5.0)), 10.))) >> bandpass()))
+        .filter(3.0, &mut node)
         .save_wav16("test/sounds/pink_noise_filtered.wav")
         .expect("Could not save file.");
 
     let color = NoiseColor::White;
     color
         .render()
-        .filter(3.0, &mut((pass() | lfo(|t| (xerp11(110.0, 880.0, spline_noise(0, t*5.0)), 10.))) >> bandpass()))
+        .filter(3.0, &mut node)
         .save_wav16("test/sounds/white_noise_filtered.wav")
         .expect("Could not save file.");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,16 @@ enum NoiseColor {
 
 
 impl NoiseColor {
-    fn render(&self) -> Wave64 {
-        let wave = match self {
+    fn render(&self, normalize: bool) -> Wave64 {
+        let mut wave = match self {
             Self::Brown => Wave64::render(44100.0, 3.0, &mut (brown())),
             Self::Pink => Wave64::render(44100.0, 3.0, &mut (pink())),
             Self::White => Wave64::render(44100.0, 3.0, &mut (white())),
         };
+
+        if normalize {
+            wave.normalize();
+        }
 
         return wave;
     }
@@ -26,23 +30,24 @@ fn main() {
 
     let color = NoiseColor::Brown;
     let mut node = (pass() | lfo(|t| (xerp11(110.0, 880.0, spline_noise(0, t*5.0)), 10.))) >> bandpass();
+    let normalize = true;
 
     color
-        .render()
+        .render(normalize)
         .filter(3.0, &mut node)
         .save_wav16("test/sounds/brown_noise_filtered.wav")
         .expect("Could not save file.");
 
     let color = NoiseColor::Pink;
     color
-        .render()
+        .render(normalize)
         .filter(3.0, &mut node)
         .save_wav16("test/sounds/pink_noise_filtered.wav")
         .expect("Could not save file.");
 
     let color = NoiseColor::White;
     color
-        .render()
+        .render(normalize)
         .filter(3.0, &mut node)
         .save_wav16("test/sounds/white_noise_filtered.wav")
         .expect("Could not save file.");


### PR DESCRIPTION
Adds a short example to create sound files from brown, pink, and white noise filtered through a bandpass function.

Run with:

```sh
cargo run --example noise_color_waves
```