### PR TITLE
Threads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use dasp::{signal, Sample, Signal};
 use signal::{Sine, ConstHz};
 
 use std::sync::mpsc;
+use std::thread;
 use std::time::Duration;
 
 
@@ -95,6 +96,12 @@ fn play_signal(device: cpal::Device, config: cpal::SupportedStreamConfig) {
 fn main() {
     println!("Exploring the 🌊's...");
 
-    let (_host, device, ssg) = host_device_setup().unwrap();
-    play_signal(device, ssg);
+    thread::spawn(|| {
+        println!("Playing signal in thread");
+        let (_host, device, ssg) = host_device_setup().unwrap();
+        play_signal(device, ssg);
+        thread::sleep(Duration::from_millis(1));
+    }).join().unwrap();
+
+    // play_signal(device, ssg);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,11 +53,21 @@ where
         Some(Duration::new(5, 0))
     )?;
 
-    stream.play()?;
+    // wait for playback to complete. Sounds won't play without the receiver being invoked.
+    // complete_rx.recv().unwrap();
 
-    // wait for playback to complete. Sounds won't play without these.
-    complete_rx.recv().unwrap();
-    stream.pause()?;
+    // Play the sine wave for 2 seconds, then pause 2 seconds, indefinitely
+    let mut num_loops = 0;
+    while num_loops < 5 {
+        stream.play()?;
+        thread::sleep(Duration::from_millis(2000));
+        stream.pause()?;
+        thread::sleep(Duration::from_millis(2000));
+
+        num_loops += 1;
+    }
+
+    // complete_rx.recv().unwrap();
 
     Ok(())
 }
@@ -100,8 +110,9 @@ fn main() {
         println!("Playing signal in thread");
         let (_host, device, ssg) = host_device_setup().unwrap();
         play_signal(device, ssg);
-        thread::sleep(Duration::from_millis(1));
     }).join().unwrap();
+
+    println!("Listening in main thread.");
 
     // play_signal(device, ssg);
 }


### PR DESCRIPTION
Play and pause the signal within a thread. Likely the final example using base `cpal`. The [`rodio`](https://docs.rs/rodio/latest/rodio/) library provides a higher-level API that exposes controls like play, pause, volume, speed, making it a better fit for the synth project (at least, initially).