### PR TITLE
Keyboard events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ cpal = "0.15.2"
 dasp = { version="0.11.0", features=["all"] }
 fundsp = "0.12.0"
 iced = { version="0.8", features=["canvas"]}
+rodio = "0.17.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ cpal = "0.15.2"
 dasp = { version="0.11.0", features=["all"] }
 fundsp = "0.12.0"
 iced = { version="0.8", features=["canvas"]}
+termion = "2.0.1"
 rodio = "0.17.1"

--- a/examples/rodio.rs
+++ b/examples/rodio.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+
+use rodio::{Decoder, OutputStream, Sink};
+use rodio::source::{SineWave, Source};
+
+use std::thread;
+
+fn main() {
+    let (_stream, stream_handle) = OutputStream::try_default().unwrap();
+    let sink = Sink::try_new(&stream_handle).unwrap();
+    
+    let source = SineWave::new(440.0).amplify(0.10);
+    sink.append(source); 
+
+    // sink.sleep_until_end();
+
+    for _ in 0..5 {
+        thread::sleep(Duration::from_secs(1));  // Start sound on initial loop
+        sink.pause();  // pause after 1 second.
+
+        thread::sleep(Duration::from_secs(1));
+        sink.play();
+    }
+}

--- a/examples/rodio.rs
+++ b/examples/rodio.rs
@@ -1,24 +1,60 @@
+use std::io::{stdin, stdout, Write};
 use std::time::Duration;
+use std::thread;
 
 use rodio::{Decoder, OutputStream, Sink};
 use rodio::source::{SineWave, Source};
 
-use std::thread;
+use termion::input::{MouseTerminal, TermRead};
+use termion::event::{Event, Key, MouseEvent};
+use termion::raw::IntoRawMode;
+
 
 fn main() {
     let (_stream, stream_handle) = OutputStream::try_default().unwrap();
     let sink = Sink::try_new(&stream_handle).unwrap();
     
     let source = SineWave::new(440.0).amplify(0.10);
-    sink.append(source); 
+    // sink.append(source);
 
     // sink.sleep_until_end();
 
-    for _ in 0..5 {
-        thread::sleep(Duration::from_secs(1));  // Start sound on initial loop
-        sink.pause();  // pause after 1 second.
+    // for _ in 0..5 {
+    //     thread::sleep(Duration::from_secs(1));  // Start sound on initial loop
+    //     sink.pause();  // pause after 1 second.
 
-        thread::sleep(Duration::from_secs(1));
-        sink.play();
+    //     thread::sleep(Duration::from_secs(1));
+    //     sink.play();
+    // }
+
+    // let mut buffer = String::new();
+    // let input = match io::stdin().read_line(&mut buffer) {
+    //     Ok(n) => {
+    //         println!("Bytes read: {}", n);
+    //         println!("User entered: {}", buffer);
+    //     },
+    //     Err(e) => {
+    //         println!("Cannae read: {e}.")
+    //     }
+    // };
+
+    let stdin = stdin();
+    let mut stdout = stdout().into_raw_mode().unwrap();
+    // let mut stdout = MouseTerminal::from(stdout().into_raw_mode().unwrap());
+    // write!(stdout, "{}{}q to exit. Click, click, click!", termion::clear::All, termion::cursor::Goto(1, 1)).unwrap();
+    stdout.flush().unwrap();
+
+    for c in stdin.events() {
+        let event = c.unwrap();
+        match event {
+            Event::Key(Key::Char('q')) => break,
+            Event::Mouse(_) => todo!("Mouse events"),
+            Event::Key(Key::Left) => todo!("Left arrow key"),
+            // Event::Unsupported(e) =>  println!("Error: {:?}", e),
+            _ => println!("Unsupported event"),
+        }
+        // Immediately returns input characters, i.e. no need for pressing Enter.
+        stdout.flush().unwrap();
     }
+
 }

--- a/examples/rodio.rs
+++ b/examples/rodio.rs
@@ -15,17 +15,16 @@ fn play() {
     let sink = Sink::try_new(&stream_handle).unwrap();
     
     let source = SineWave::new(440.0).amplify(0.10);
+    println!("\rPlaying sound...");
+
     sink.append(source);
+    sink.play();
+    thread::sleep(Duration::from_secs(1));
+    sink.pause();
 
     // sink.sleep_until_end();
 
-    for _ in 0..1 {
-        thread::sleep(Duration::from_secs(1));  // Start sound on initial loop
-        sink.pause();  // pause after 1 second.
-
-        thread::sleep(Duration::from_secs(1));
-        sink.play();
-    }
+    println!("\rDone playing.\r")
 }
 
 fn main() {

--- a/examples/rodio.rs
+++ b/examples/rodio.rs
@@ -43,15 +43,18 @@ fn main() {
     // let mut stdout = MouseTerminal::from(stdout().into_raw_mode().unwrap());
     // write!(stdout, "{}{}q to exit. Click, click, click!", termion::clear::All, termion::cursor::Goto(1, 1)).unwrap();
     stdout.flush().unwrap();
+    println!("Captures Mouse Key events\r\nPress q to quit.\r");
 
     for c in stdin.events() {
+
         let event = c.unwrap();
         match event {
             Event::Key(Key::Char('q')) => break,
+            // Event::Key(Key::Char(c)) => c,
             Event::Mouse(_) => todo!("Mouse events"),
             Event::Key(Key::Left) => todo!("Left arrow key"),
             // Event::Unsupported(e) =>  println!("Error: {:?}", e),
-            _ => println!("Unsupported event"),
+            _ => println!("Unsupported event\r"),
         }
         // Immediately returns input characters, i.e. no need for pressing Enter.
         stdout.flush().unwrap();

--- a/examples/rodio.rs
+++ b/examples/rodio.rs
@@ -10,46 +10,40 @@ use termion::event::{Event, Key, MouseEvent};
 use termion::raw::IntoRawMode;
 
 
-fn main() {
+fn play() {
     let (_stream, stream_handle) = OutputStream::try_default().unwrap();
     let sink = Sink::try_new(&stream_handle).unwrap();
     
     let source = SineWave::new(440.0).amplify(0.10);
-    // sink.append(source);
+    sink.append(source);
 
     // sink.sleep_until_end();
 
-    // for _ in 0..5 {
-    //     thread::sleep(Duration::from_secs(1));  // Start sound on initial loop
-    //     sink.pause();  // pause after 1 second.
+    for _ in 0..1 {
+        thread::sleep(Duration::from_secs(1));  // Start sound on initial loop
+        sink.pause();  // pause after 1 second.
 
-    //     thread::sleep(Duration::from_secs(1));
-    //     sink.play();
-    // }
+        thread::sleep(Duration::from_secs(1));
+        sink.play();
+    }
+}
 
-    // let mut buffer = String::new();
-    // let input = match io::stdin().read_line(&mut buffer) {
-    //     Ok(n) => {
-    //         println!("Bytes read: {}", n);
-    //         println!("User entered: {}", buffer);
-    //     },
-    //     Err(e) => {
-    //         println!("Cannae read: {e}.")
-    //     }
-    // };
-
+fn main() {
     let stdin = stdin();
     let mut stdout = stdout().into_raw_mode().unwrap();
     // let mut stdout = MouseTerminal::from(stdout().into_raw_mode().unwrap());
     // write!(stdout, "{}{}q to exit. Click, click, click!", termion::clear::All, termion::cursor::Goto(1, 1)).unwrap();
     stdout.flush().unwrap();
-    println!("Captures Mouse Key events\r\nPress q to quit.\r");
+    println!("Captures Mouse Key events.");
+    println!("\rPress p to play sound.");
+    println!("\rPress q to quit.");
 
     for c in stdin.events() {
 
         let event = c.unwrap();
         match event {
             Event::Key(Key::Char('q')) => break,
+            Event::Key(Key::Char('p')) => play(),
             // Event::Key(Key::Char(c)) => c,
             Event::Mouse(_) => todo!("Mouse events"),
             Event::Key(Key::Left) => todo!("Left arrow key"),


### PR DESCRIPTION
Add an example to play and pause sounds using `rodio`, with `termion` for reading keyboard inputs.