### PR TITLE
Play pause loop

### DIFF
--- a/examples/rodio.rs
+++ b/examples/rodio.rs
@@ -1,4 +1,6 @@
 use std::io::{stdin, stdout, Write};
+use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{self, Sender, Receiver};
 use std::time::Duration;
 use std::thread;
 
@@ -27,7 +29,7 @@ fn play() {
         sink.sleep_until_end();
         
     });
-    thread::sleep(Duration::from_secs(2));
+    thread::sleep(Duration::from_secs(5));
 
     // sink.sleep_until_end();  // put this in a thread, have the thread get killed by a listener when an event is sent?
 
@@ -35,28 +37,66 @@ fn play() {
     println!("Done playing.\r");
 }
 
-fn main() {
+fn input_thread(tx: Sender<Event>) -> thread::JoinHandle<()> {
+    std::thread::Builder::new().name("input_thread".to_string()).spawn(move || loop {
+        let cmd = get_input();
+        println!("Input: {:?}", cmd);
+        let tx1 = mpsc::Sender::clone(&tx);
+        tx1.send(cmd).expect("Input thread should be able to capture multiple events.");
+    }).expect("Input thread should be able to be created.")
+
+}
+
+fn get_input() -> Event {
     let stdin = stdin();
+    // Immediately returns input characters, i.e. no need for pressing Enter.
+    // Only works if you do `let mut <variable>`. 
     let mut stdout = stdout().into_raw_mode().unwrap();
     // let mut stdout = MouseTerminal::from(stdout().into_raw_mode().unwrap());
     // write!(stdout, "{}{}q to exit. Click, click, click!", termion::clear::All, termion::cursor::Goto(1, 1)).unwrap();
-    stdout.flush().unwrap();
+    // stdout.flush().unwrap();
     println!("Captures Mouse Key events.\r");
     println!("Press p to play sound.\r");
     println!("Press q to quit.\r");
 
-    for c in stdin.events() {
-
-        let event = c.unwrap();
-        match event {
-            Event::Key(Key::Char('q') | Key::Ctrl('c')) => break,
-            Event::Key(Key::Char('p')) => play(),
-            // Event::Key(Key::Char(c)) => c,
-            Event::Mouse(_) => todo!("Mouse events"),
-            // Event::Unsupported(e) =>  println!("Error: {:?}", e),
-            _ => println!("{:?}\r", event),
-        }
-        // Immediately returns input characters, i.e. no need for pressing Enter.
-        stdout.flush().unwrap();
+    // for c in stdin.events() {
+    //     let event = c.unwrap();
+    //     match event {
+    //         Event::Key(Key::Char('q') | Key::Ctrl('c')) => break,
+    //         Event::Key(Key::Char('p')) => play(),
+    //         // Event::Key(Key::Char(c)) => c,
+    //         Event::Mouse(_) => todo!("Mouse events"),
+    //         // Event::Unsupported(e) =>  println!("Error: {:?}", e),
+    //         _ => println!("{:?}\r", event),
+    //     }
+    //     // stdout.flush().unwrap();
+    // }
+    match stdin.events().next() {
+        Some(n) => n.unwrap(),
+        None => Event::Key(Key::Char('q'))
     }
+}
+
+fn play_thread(rx: Arc<Mutex<Receiver<Event>>>) {
+    let player = std::thread::Builder::new().name("play_thread".to_string()).spawn(move || {
+        let cmd = rx.lock().unwrap().recv().unwrap();
+        match cmd {
+            Event::Key(Key::Char('p')) => play(),
+            Event::Key(Key::Char('q') | Key::Ctrl('c')) => std::process::exit(0),
+            _ => println!("{:?}\r", cmd),
+        }
+    }).unwrap();
+
+    player.join().expect("Player thread should play the sound.");
+}
+
+fn main() {
+    let (tx, rx) = mpsc::channel();
+
+    let input_thread = input_thread(tx);
+
+    let receiver = Arc::new(Mutex::new(rx));
+    play_thread(receiver);
+
+    input_thread.join().unwrap();
 }


### PR DESCRIPTION
Separate keyboard input and play threads allow for sending keyboard events to the play thread, playing, pausing, and stopping audio!

Big thanks to @linhub15, whose [`rust-music-player`](https://github.com/linhub15/rust-music-player) code help me figure out how to set up the event loop and send data across channels.